### PR TITLE
Demo override authority in tests

### DIFF
--- a/hello-impl/src/test/scala/com/example/hello/impl/HelloServiceSpec.scala
+++ b/hello-impl/src/test/scala/com/example/hello/impl/HelloServiceSpec.scala
@@ -19,8 +19,9 @@ class HelloServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAl
   val client: HelloService = server.serviceClient.implement[HelloService]
   val grpcClient: Option[GreeterServiceClient] = server.playServer.httpsPort.map{ httpsPort =>
     val settings = GrpcClientSettings
-      .connectToServiceAt("localhost", httpsPort)(server.actorSystem)
+      .connectToServiceAt("127.0.0.1", httpsPort)(server.actorSystem)
         .withSSLContext(server.clientSslContext.get)
+        .withOverrideAuthority("localhost")
 
     GreeterServiceClient(settings)(server.materializer, server.executionContext)
   }


### PR DESCRIPTION
Use 
```scala
    val settings = GrpcClientSettings
      .connectToServiceAt("127.0.0.1", httpsPort)(server.actorSystem)
        .withSSLContext(server.clientSslContext.get)
        .withOverrideAuthority("localhost")
```

instead of 

```scala
    val settings = GrpcClientSettings
      .connectToServiceAt("localhost", httpsPort)(server.actorSystem)
        .withSSLContext(server.clientSslContext.get)
```

to demo the impact/use of `withOverrideAuthority` in tests.