### PR TITLE
Demonstrate unit tests for grpc client

### DIFF
--- a/hello-proxy-impl/src/main/scala/com/example/helloproxy/impl/HelloProxyLoader.scala
+++ b/hello-proxy-impl/src/main/scala/com/example/helloproxy/impl/HelloProxyLoader.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.actor.{ ActorSystem, CoordinatedShutdown }
 import akka.grpc.GrpcClientSettings
-import akka.grpc.scaladsl.RestartingClient
+import akka.grpc.scaladsl.AkkaGrpcClient
 import com.example.hello.api.HelloService
 import com.example.helloproxy.api.HelloProxyService
 import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
@@ -37,29 +37,23 @@ abstract class HelloProxyApplication(context: LagomApplicationContext)
   private implicit val dispatcher: ExecutionContextExecutor = actorSystem.dispatcher
   private implicit val sys: ActorSystem = actorSystem
 
-  // A) Create the gRPC client
-  //   A.1) gRPC client settings
   private lazy val settings = GrpcClientSettings
     .usingServiceDiscovery(GreeterService.name)
     .withServicePortName("https")
     .withDeadline(Duration.create(5, TimeUnit.SECONDS)) // response timeout
     .withConnectionAttempts(5) // use a small reconnectionAttempts value to cause a client reload in case of failure
-  //   A.2) create a client factory
-  private lazy val clientConstructor = () => new GreeterServiceClient(settings)(materializer, dispatcher)
-  //   A.3) create a restarting client with the client factory to handle reconnections
-  lazy val greeterServiceClient: RestartingClient[GreeterServiceClient] = new RestartingClient[GreeterServiceClient](clientConstructor)
 
-  //   A.4) register a shuhtdown task to release resources of the client
+  lazy val greeterServiceClient: GreeterServiceClient = GreeterServiceClient(settings)
+  //  Register a shutdown task to release resources of the client
   coordinatedShutdown
     .addTask(
       CoordinatedShutdown.PhaseServiceUnbind,
       "shutdown-greeter-service-grpc-client"
     ) { () => greeterServiceClient.close() }
 
-  // B) Create the lagom client. Bind the HelloService client
   lazy val helloService = serviceClient.implement[HelloService]
 
-  // C) Bind the service that this server provides
   override lazy val lagomServer = serverFor[HelloProxyService](wire[HelloProxyServiceImpl])
 
 }
+

--- a/hello-proxy-impl/src/main/scala/com/example/helloproxy/impl/HelloProxyServiceImpl.scala
+++ b/hello-proxy-impl/src/main/scala/com/example/helloproxy/impl/HelloProxyServiceImpl.scala
@@ -1,6 +1,5 @@
 package com.example.helloproxy.impl
 
-import akka.grpc.scaladsl.RestartingClient
 import com.example.hello.api.HelloService
 import com.example.helloproxy.api.HelloProxyService
 import com.lightbend.lagom.scaladsl.api.ServiceCall
@@ -13,18 +12,13 @@ import scala.concurrent.{ ExecutionContext, Future }
   */
 class HelloProxyServiceImpl(
                              helloService: HelloService,
-                             greeterClient: RestartingClient[GreeterServiceClient])(implicit exCtx: ExecutionContext) extends HelloProxyService {
+                             greeterClient: GreeterServiceClient)(implicit exCtx: ExecutionContext) extends HelloProxyService {
 
   def proxyViaHttp(id: String) = ServiceCall { _ =>
-    val eventualString: Future[String] = helloService.hello(id).invoke()
-    eventualString
+    helloService.hello(id).invoke()
   }
 
   def proxyViaGrpc(id: String) = ServiceCall { _ =>
-    val eventualString: Future[String] =
-      greeterClient.withClient(
-        _.sayHello(HelloRequest(id)).map(_.message)
-      )
-    eventualString
+    greeterClient.sayHello(HelloRequest(id)).map(_.message)
   }
 }

--- a/hello-proxy-impl/src/main/scala/com/example/helloproxy/impl/HelloProxyServiceImpl.scala
+++ b/hello-proxy-impl/src/main/scala/com/example/helloproxy/impl/HelloProxyServiceImpl.scala
@@ -5,7 +5,7 @@ import com.example.helloproxy.api.HelloProxyService
 import com.lightbend.lagom.scaladsl.api.ServiceCall
 import example.myapp.helloworld.grpc.{ GreeterServiceClient, HelloRequest }
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.ExecutionContext
 
 /**
   * Implementation of the HelloStreamService.

--- a/hello-proxy-impl/src/test/scala/com/example/helloproxy/impl/HelloProxyServiceImplSpec.scala
+++ b/hello-proxy-impl/src/test/scala/com/example/helloproxy/impl/HelloProxyServiceImplSpec.scala
@@ -1,0 +1,101 @@
+package com.example.helloproxy.impl
+
+import akka.actor.ActorSystem
+import akka.discovery.SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.discovery.{ Lookup, SimpleServiceDiscovery }
+import akka.grpc.scaladsl.AkkaGrpcClient
+import akka.stream.Materializer
+import akka.{ Done, NotUsed }
+import com.example.hello.api.HelloService
+import com.example.helloproxy.api.HelloProxyService
+import com.lightbend.lagom.scaladsl.api.{ ProvidesAdditionalConfiguration, ServiceCall }
+import com.lightbend.lagom.scaladsl.server.LocalServiceLocator
+import com.lightbend.lagom.scaladsl.testkit.ServiceTest
+import com.typesafe.config.ConfigFactory
+import example.myapp.helloworld.grpc.{ GreeterService, GreeterServiceClient, HelloReply, HelloRequest }
+import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
+
+import scala.collection.immutable
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+
+class HelloProxyServiceImplSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll {
+
+  private val server: ServiceTest.TestServer[HelloProxyApplication] =
+    ServiceTest.startServer(ServiceTest.defaultSetup) { ctx =>
+      new HelloProxyApplication(ctx)
+        with LocalServiceLocator
+        with ProvidesAdditionalConfiguration {
+
+        // uses Lagom's `ProvidesAdditionalConfiguration` cake layer to setup
+        // a test-friendly "akka.discovery.method" (see below)
+        override def additionalConfiguration =
+          super.additionalConfiguration ++ ConfigFactory.parseString(
+            s"akka.discovery.method = ${classOf[PlaceholderServiceDiscovery].getName}"
+          )
+
+        // overrides the HTTP client to inject a stub
+        override lazy val helloService = new HelloServiceClientStub
+        override lazy val greeterServiceClient: GreeterServiceClient = new GreeterServiceClientStub
+      }
+    }
+
+  val client: HelloProxyService = server.serviceClient.implement[HelloProxyService]
+
+  override protected def afterAll(): Unit = {
+    server.stop()
+  }
+
+
+  implicit val mat: Materializer = server.materializer
+
+  "HelloProxy service" should {
+
+    "roundtrip over HTTP" in {
+      client.proxyViaHttp("Alice").invoke().map { answer =>
+        answer should ===("Stubbed - Hi Alice!")
+      }
+    }
+
+    "roundtrip over gRPC" in {
+      client.proxyViaGrpc("Alice").invoke().map { answer =>
+        answer should ===("Stubbed - Hi Alice! (gRPC)")
+      }
+    }
+
+  }
+
+}
+
+// At the moment, gRPC client obtains a `SimpleServiceDiscovery` from the ActorSystem default settings
+// but this test doesn't exercise that `SimpleServiceDiscovery` instance so we use a noop placeholder.
+class PlaceholderServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscovery {
+  implicit val exCtx: ExecutionContext = system.dispatcher
+
+  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = Future {
+    Resolved(lookup.serviceName, immutable.Seq(ResolvedTarget("localhost", None, None)))
+  }
+}
+
+class HelloServiceClientStub extends HelloService {
+  override def hello(id: String): ServiceCall[NotUsed, String] = ServiceCall {
+    _ => Future.successful(s"Stubbed - Hi $id!")
+  }
+}
+
+class GreeterServiceClientStub extends GreeterServiceClient with StubbedAkkaGrpcClient {
+  def sayHello(in: HelloRequest): Future[HelloReply] =
+    Future.successful(HelloReply(s"Stubbed - Hi ${in.name}! (gRPC)"))
+}
+
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+protected trait StubbedAkkaGrpcClient extends AkkaGrpcClient{
+  private val _closed = Promise[Done]()
+  override def close(): Future[Done] = {
+    _closed.trySuccess(Done)
+    _closed.future
+  }
+  override def closed(): Future[Done] = _closed.future
+}

--- a/hello-proxy-impl/src/test/scala/com/example/helloproxy/impl/HelloProxyServiceImplSpec.scala
+++ b/hello-proxy-impl/src/test/scala/com/example/helloproxy/impl/HelloProxyServiceImplSpec.scala
@@ -69,16 +69,6 @@ class HelloProxyServiceImplSpec extends AsyncWordSpec with Matchers with BeforeA
 
 }
 
-// At the moment, gRPC client obtains a `SimpleServiceDiscovery` from the ActorSystem default settings
-// but this test doesn't exercise that `SimpleServiceDiscovery` instance so we use a noop placeholder.
-class PlaceholderServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscovery {
-  implicit val exCtx: ExecutionContext = system.dispatcher
-
-  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = Future {
-    Resolved(lookup.serviceName, immutable.Seq(ResolvedTarget("localhost", None, None)))
-  }
-}
-
 class HelloServiceClientStub extends HelloService {
   override def hello(id: String): ServiceCall[NotUsed, String] = ServiceCall {
     _ => Future.successful(s"Stubbed - Hi $id!")
@@ -93,6 +83,17 @@ class GreeterServiceClientStub extends GreeterServiceClient with StubbedAkkaGrpc
 
 // ------------------------------------------------------------------------
 // ------------------------------------------------------------------------
+
+// At the moment, gRPC client obtains a `SimpleServiceDiscovery` from the ActorSystem default settings
+// but this test doesn't exercise that `SimpleServiceDiscovery` instance so we use a noop placeholder.
+class PlaceholderServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscovery {
+  implicit val exCtx: ExecutionContext = system.dispatcher
+
+  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = Future {
+    Resolved(lookup.serviceName, immutable.Seq(ResolvedTarget("localhost", None, None)))
+  }
+}
+
 protected trait StubbedAkkaGrpcClient extends AkkaGrpcClient {
   private val _closed = Promise[Done]()
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 // The Lagom plugin
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-M4")
 // Akka GRPC
-addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.4.1+49-c97dd796")
+addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.4.1+59-0cae3750+20181112-2316")
 
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 // The Lagom plugin
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-M4")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-RC1")
 // Akka GRPC
-addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.4.1+59-0cae3750+20181112-2316")
+addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.4.2")
 
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,7 @@
 // The Lagom plugin
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-M4")
 // Akka GRPC
-addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.4.1")
-
+addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.4.1+49-c97dd796")
 
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")


### PR DESCRIPTION
Fixes #18 
Blocked by https://github.com/akka/akka-grpc/pull/449 

In Lagom gRPC is most probably used in service-to-service communications (intra-application) though it can also be used to communicate to external/remote services.

service-to-service communication shuold support client-side discovery as well as server-side discovery so lagom users will probably need to use service discovery based gRPC client instead of hardcoded (`hohst:port`) ones.

When using a gRPC client it should be possble to stub on unit tests so generated client code should be easily replaced. This motivated https://github.com/akka/akka-grpc/pull/440, https://github.com/akka/akka-grpc/pull/442 and https://github.com/akka/akka-grpc/pull/449. It is also necessary to stub and inject a service discovery for tests and a faked shutdown mechanism so that users don't need to implement `AkkaGrpcClient` methods (which is part of every `XServiceClient` instance). This PR introduces `StubbedAkkaGrpcCleient`which could eventually be promoted to `akka-grpc-testkit`.